### PR TITLE
update github url on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,6 @@ layout: default
   {% comment %}
     {% include icon-github.html %}
   {% endcomment %}
-  <h2><a href="https://github.com/orgs/betamore/teams/fewd/repositories">GitHub</a></h2>
+  <h2><a href="https://github.com/betamore/fewd">GitHub</a></h2>
   </div>
 </div>


### PR DESCRIPTION
The github link on the homepage is broken. I updated it to what I *think* is the correct URL :)